### PR TITLE
Resolution Fixes, Debugging tools for test.py

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -19,6 +19,15 @@ discord_channel = "*"
 screen_resolution = "1920x1080"
 adjust_x = 0 # adjust x by pixels. e.g. 3 = 3 pixels right, -2 = 2 pixles left
 adjust_y = 0 # adjust y by pixels. e.g. 2 = 2 pixels up, -20 = 20 pixles down
+
+# These scalars should only be adjusted if text isn't being correctly identified by start.py,
+# or if you are debugging test.py to find the right fit. These operate as multipliers for the current resolution,
+# so if you are operating at a non 1080p resolution, you will likely need to adjust these (use test.py and sample images)
+discuss_offset_scalars = "0.08x0.18" # top x left
+discuss_dimension_scalars = "0.7x0.25" # width x height
+ending_offset_scalars = "0.065x0.22" # top x left
+ending_dimension_scalars = "0.5x0.13" # width x height
+
 time_delay = 0 # adjust time delay. 1 = one second more delay, -0.5 = 0.5 seconds less time
 
 # time_delay is added or taken away from the delay set between when the screen 
@@ -26,6 +35,8 @@ time_delay = 0 # adjust time delay. 1 = one second more delay, -0.5 = 0.5 second
 
 debug_mode = False #Shows parsed output coming from image to text algorithm
 
+test_window_type = "ending" # use "ending" or "discuss" to identify what window type test.py will test with
+# test_window_type = "discuss"
 
 # -------------------------------------------------
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -23,20 +23,22 @@ adjust_y = 0 # adjust y by pixels. e.g. 2 = 2 pixels up, -20 = 20 pixles down
 # These scalars should only be adjusted if text isn't being correctly identified by start.py,
 # or if you are debugging test.py to find the right fit. These operate as multipliers for the current resolution,
 # so if you are operating at a non 1080p resolution, you will likely need to adjust these (use test.py and sample images)
-discuss_offset_scalars = "0.08x0.18" # top x left
-discuss_dimension_scalars = "0.7x0.25" # width x height
-ending_offset_scalars = "0.065x0.22" # top x left
-ending_dimension_scalars = "0.5x0.13" # width x height
+ending_offset_scalars = "0.08x0.18" # top x left
+ending_dimension_scalars = "0.7x0.25" # width x height
+discuss_offset_scalars = "0.065x0.22" # top x left
+discuss_dimension_scalars = "0.5x0.13" # width x height
 
 time_delay = 0 # adjust time delay. 1 = one second more delay, -0.5 = 0.5 seconds less time
 
 # time_delay is added or taken away from the delay set between when the screen 
 # shows imposter, crewmate, or vote ended to when the round starts
 
-debug_mode = False #Shows parsed output coming from image to text algorithm
+debug_mode = False #Shows parsed output coming from image to text algorithm (enable for test.py)
 
-test_window_type = "ending" # use "ending" or "discuss" to identify what window type test.py will test with
-# test_window_type = "discuss"
+debug_disable_discord = False # Disable Discord hooks when testing the OCR and image fit (enable for test.py)
+
+#test_window_type = "ending" # use "ending" or "discuss" to identify what window type test.py will test with
+test_window_type = "discuss"
 
 # -------------------------------------------------
 

--- a/modules/module_grabscreen.py
+++ b/modules/module_grabscreen.py
@@ -13,9 +13,15 @@ import time
 from modules import module_process
 from modules.config import *
 
+discuss_top, discuss_left = float(discuss_offset_scalars.split("x")[0]), float(discuss_offset_scalars.split("x")[1])
+discuss_width, discuss_height = float(discuss_dimension_scalars.split("x")[0]), float(discuss_dimension_scalars.split("x")[1])
+
+ending_top, ending_left = float(ending_offset_scalars.split("x")[0]), float(ending_offset_scalars.split("x")[1])
+ending_width, ending_height = float(ending_dimension_scalars.split("x")[0]), float(ending_dimension_scalars.split("x")[1])
+
 def grabDiscussionTitle(xResolution: int, yResolution: int):
     
-    settings = {'top': int(0.08 * yResolution) + adjust_y, 'left':int(xResolution * 0.18) + adjust_x, 'width':int(xResolution * 0.7), 'height':int(0.25 * yResolution)}
+    settings = {'top': int(discuss_top * yResolution) + adjust_y, 'left':int(xResolution * discuss_left) + adjust_x, 'width':int(xResolution * discuss_width), 'height':int(discuss_height * yResolution)}
 
     sct = mss()
 
@@ -35,7 +41,7 @@ def grabDiscussionTitle(xResolution: int, yResolution: int):
         module_process.processDiscussion(frame)
 
 def grabEndingScreen(xResolution: int, yResolution: int):
-    settings = {'top': int(0.065 * yResolution) + adjust_y, 'left':int(xResolution * 0.22) + adjust_x, 'width':int(xResolution * 0.5), 'height':int(0.13 * yResolution)} 
+    settings = {'top': int(ending_top * yResolution) + adjust_y, 'left':int(xResolution * ending_left) + adjust_x, 'width':int(xResolution * ending_width), 'height':int(ending_height * yResolution)} 
 
     sct = mss()
 

--- a/modules/module_process.py
+++ b/modules/module_process.py
@@ -7,9 +7,10 @@
 # -------------------------------------------------
 
 from modules import module_sendcommand
-# web = module_sendcommand.web() # Python will initalise this object when this when program starts
-
 from modules.config import *
+if not debug_disable_discord:
+    web = module_sendcommand.web() # Python will initalise this object when this when program starts
+
 from PIL import Image
 import pytesseract #pip3 install pytesseract
 import os
@@ -19,7 +20,7 @@ pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tessera
 
 def processDiscussion(image: complex):
     delay = 7 #Delay between voting ends and round starting
-    discussion = {"?","who",'whos',"imposter?","iniposior?","inijposior?","impostor?","inoster?","tnrpester?","tnsester?","inraostor?","inaoster?","tnsoster?","tnpester?",'hnnsester?'}
+    discussion = {"?","who","whos","wino","imposter?","iniposior?","inposior?","inposter?","inijposior?","impostor?","inoster?","tnrpester?","tnsester?","inraostor?","inaoster?","tnsoster?","tnpester?",'hnnsester?'}
     voting = {"voting", "results","result","vetting","vartine"}
 
     raw_output = pytesseract.image_to_string(image)
@@ -31,13 +32,15 @@ def processDiscussion(image: complex):
 
     if len(out.intersection(discussion)) != 0: #if one of the keywords for discussion time is present
         print("DISCUSSION [UNMUTED]")
-        web.unmute()
+        if not debug_disable_discord:
+            web.unmute()
 
     elif len(out.intersection(voting)) != 0: #if one of the keywords for ended voting is present
         print("VOTING ENDED [MUTING SOON]")
 
         time.sleep(delay + time_delay)
-        web.mute() #mute
+        if not debug_disable_discord:
+            web.mute() #mute
 
 def processEnding(image: complex):
     delay = 4 #Delay between getting role and game starting
@@ -55,22 +58,26 @@ def processEnding(image: complex):
 
     if len(out.intersection(defeat)) != 0: #if one of the keywords for defeat is present
         print("DEFEAT [UNMUTED]")
-        web.unmute()
+        if not debug_disable_discord:
+            web.unmute()
 
     elif len(out.intersection(victory)) != 0: #if one of the keywords for victory is present
         print("VICTORY [UNMUTED]")
-        web.unmute()
+        if not debug_disable_discord:
+            web.unmute()
 
     elif len(out.intersection(crewmate)) != 0: #if one of the keywords for crewmate is present
         print("YOU GOT CREWMATE [MUTING SOON]")
 
         time.sleep(delay + time_delay)
-        web.mute() #mute
+        if not debug_disable_discord:
+            web.mute() #mute
 
     elif len(out.intersection(imposter)) != 0: #if one of the keywords for imposter is present
         print("YOU GOT IMPOSTER [MUTING SOON]")
 
         time.sleep(delay + time_delay)
-        web.mute() #mute
+        if not debug_disable_discord:
+            web.mute() #mute
     else:
         pass

--- a/modules/module_process.py
+++ b/modules/module_process.py
@@ -7,7 +7,7 @@
 # -------------------------------------------------
 
 from modules import module_sendcommand
-web = module_sendcommand.web() # Python will initalise this object when this when program starts
+# web = module_sendcommand.web() # Python will initalise this object when this when program starts
 
 from modules.config import *
 from PIL import Image

--- a/start.py
+++ b/start.py
@@ -9,6 +9,7 @@ os.system("cls")
 print("\n[*] Warming up engine...\n\n")
 print("[*] A chrome window will open now...\n[*] Enter your discord credentials in the window before we start")
 from modules import module_grabscreen
+from modules.config import screen_resolution
 
 from threading import Thread
 
@@ -30,5 +31,8 @@ class start_engine:
         thread2.start()
         thread3.start()
 
+# Use the x and y resolutions from config.py
+x, y = int(screen_resolution.split("x")[0]), int(screen_resolution.split("x")[1])
+
 if __name__ == "__main__":
-    start = start_engine(1280, 720) #Please leave these values alone
+    start = start_engine(x, y)

--- a/test.py
+++ b/test.py
@@ -4,11 +4,12 @@ from PIL import Image
 import numpy as np
 import time
 
+from modules import module_process
 from modules.config import *
 
 x, y = int(screen_resolution.split("x")[0]), int(screen_resolution.split("x")[1])
 
-if (test_window_type == "discuss"):
+if test_window_type == "discuss":
     top, left = float(discuss_offset_scalars.split("x")[0]), float(discuss_offset_scalars.split("x")[1])
     width, height = float(discuss_dimension_scalars.split("x")[0]), float(discuss_dimension_scalars.split("x")[1])
 elif test_window_type == "ending":
@@ -29,6 +30,11 @@ while 1:
     img_bgr = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
 
     time.sleep(1)
+
+    if test_window_type == "discuss":
+        module_process.processDiscussion(img_bgr)
+    elif test_window_type == "ending":
+        module_process.processEnding(img_bgr)
 
     cv2.imshow('Among Us Test', np.array(img_bgr))
     if cv2.waitKey(25) & 0xFF == ord('q'):

--- a/test.py
+++ b/test.py
@@ -8,7 +8,18 @@ from modules.config import *
 
 x, y = int(screen_resolution.split("x")[0]), int(screen_resolution.split("x")[1])
 
-mon = {'top': int(0.1*y) + adjust_y, 'left':int(x*0.18) + adjust_x, 'width':int(x*0.7), 'height':int(0.25*y)}
+if (test_window_type == "discuss"):
+    top, left = float(discuss_offset_scalars.split("x")[0]), float(discuss_offset_scalars.split("x")[1])
+    width, height = float(discuss_dimension_scalars.split("x")[0]), float(discuss_dimension_scalars.split("x")[1])
+elif test_window_type == "ending":
+    top, left = float(ending_offset_scalars.split("x")[0]), float(ending_offset_scalars.split("x")[1])
+    width, height = float(ending_dimension_scalars.split("x")[0]), float(ending_dimension_scalars.split("x")[1])
+else:
+    print("Invalid test_window_type specified")
+    exit
+    
+
+mon = {'top': int(top*y) + adjust_y, 'left':int(x*left) + adjust_x, 'width':int(x*width), 'height':int(height*y)}
 
 sct = mss()
 


### PR DESCRIPTION
Loving this bot! I encountered some issues last night messing with it at 2560x1440p, and discovered some bugs and areas where the OCR could be improved with this PR.

1. (bug) `start_engine` didn't use the resolution provided in config.py
2. (bug) the scalars for discussion and ending capture screens were reversed; the window is tiny for ending capture, and large for the discussion screen capture (erroneously), so I swapped them
3. The above mentioned scalar values are tricky at >1080p resolution, so I moved them into config.py to make debugging easier
4. The test.py script has been expanded to respect the scalars mentioned above, as well as allowing the OCR output to show up in console while it runs. I also added support to disable the Discord hooks when debugging (when you only want to test the OCR output).
5. You can test the specific "discuss" and "ending" capture windows by using the `test_window_type` in config.py, for the test.py utility.
